### PR TITLE
Re-build odm2api

### DIFF
--- a/odm2api/meta.yaml
+++ b/odm2api/meta.yaml
@@ -9,7 +9,7 @@ source:
     git_tag: v{{ version }}-alpha
 
 build:
-    number: 2
+    number: 0
     skip: True  # [py3k]
     script: python setup.py install --single-version-externally-managed --record record.txt
 


### PR DESCRIPTION
Removed the previous `beta` tag from the channel.

(Same as #25, but now from the repo fork :grin:)
