### PR TITLE
Pin conda-build and conda-build-all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: generic
 
 os:
     - osx
@@ -21,8 +21,9 @@ install:
     - export CONDA_NPY=19
 
     - conda config --add channels odm2
-    - conda install --yes --quiet --channel conda-forge obvious-ci conda-build-all
+    - conda install --yes --quiet -c conda-forge obvious-ci
     - obvci_install_conda_build_tools.py
+    - conda install -c conda-forge conda-build-all=0.13.3 conda-build=1.21.11 --yes
 
     # Expand external recipe sources.
     - python scripts/expand_source.py

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -36,10 +36,10 @@ export CONDA_NPY='19'
 export PYTHONUNBUFFERED=1
 echo "$config" > ~/.condarc
 
-conda update --yes --quiet conda
-conda install --yes --quiet --channel conda-forge obvious-ci conda-build-all
-conda install --yes anaconda-client
-conda install --yes conda-build
+conda update conda --yes
+conda install -c conda-forge obvious-ci --yes
+conda install -c conda-forge conda-build-all=0.13.3 conda-build=1.21.11 --yes
+conda install jinja2 anaconda-client --yes
 
 # A lock sometimes occurs with incomplete builds.
 conda clean --lock


### PR DESCRIPTION
Pin `conda-build-all` to `0.13.3` and `conda-build` to `1.21.11` until the former is ready for the `2.0` version of the latter.
