### PR TITLE
Add a patched version of conda-build-all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,15 @@ install:
   - conda config --add channels odm2
   - conda install --yes -c odm2 -c conda-forge obvious-ci conda-build-all
   - obvci_install_conda_build_tools.py
+  # Temporary workaround to boostrap our conda-build-all build.
+  - conda install --yes conda-build=2.0.10
 
   - conda info
 
 script:
-    - if [[ "$BINSTAR_TOKEN" == "" ]]; then
-        export UPLOAD="";
-      else
-        export UPLOAD="--upload-channels odm2";
-      fi
-    - conda-build-all ./recipes $UPLOAD --inspect-channels odm2 --matrix-conditions "numpy >=1.11" "python >=2.7,<3|>=3.4,<3.6"
+  - if [[ "$BINSTAR_TOKEN" == "" ]]; then
+      export UPLOAD="";
+    else
+      export UPLOAD="--upload-channels odm2";
+    fi
+  - conda-build-all ./recipes $UPLOAD --inspect-channels odm2 --matrix-conditions "numpy >=1.11" "python >=2.7,<3|>=3.4,<3.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,8 @@ install:
   - cmd: conda config --add channels odm2
   - cmd: conda install --yes -c odm2 -c conda-forge obvious-ci conda-build-all
   - cmd: obvci_install_conda_build_tools.py
+  # Temporary workaround to boostrap our conda-build-all build.
+  - cmd: conda install --yes conda-build=2.0.10
 
   - cmd: conda info
 

--- a/recipes/conda-build-all/conda_build2.patch
+++ b/recipes/conda-build-all/conda_build2.patch
@@ -1,0 +1,65 @@
+diff --git a/conda_build_all/build.py b/conda_build_all/build.py
+index 0c54171..237774e 100644
+--- a/conda_build_all/build.py
++++ b/conda_build_all/build.py
+@@ -9,7 +9,12 @@ import conda_build.build as build_module
+ from conda_build.metadata import MetaData
+ import conda_build.config
+ from conda.lock import Locked
+-from conda_build.build import bldpkg_path
++
++try:
++    from conda_build.api import get_output_file_path
++except ImportError:
++    from conda_build.build import bldpkg_path as get_output_file_path
++
+ import conda_build.source
+ import binstar_client
+ from binstar_client.utils.detect import detect_package_type, get_attrs
+@@ -39,10 +44,7 @@ def build(meta, test=True):
+ 
+ def upload(cli, meta, owner, channels=['main'], config=None):
+     """Upload a distribution, given the build metadata."""
+-    if hasattr(conda_build, 'api'):
+-        fname = bldpkg_path(meta, config)
+-    else:
+-        fname = bldpkg_path(meta)
++    fname = get_output_file_path(meta)
+     package_type = detect_package_type(fname)
+     package_attrs, release_attrs, file_attrs = get_attrs(package_type, fname)
+     package_name = package_attrs['name']
+diff --git a/conda_build_all/tests/integration/test_builder.py b/conda_build_all/tests/integration/test_builder.py
+index c190b5f..09a611a 100644
+--- a/conda_build_all/tests/integration/test_builder.py
++++ b/conda_build_all/tests/integration/test_builder.py
+@@ -216,7 +216,7 @@ class Test_compute_build_distros(RecipeCreatingUnit):
+                     'my_py_package-2.0-py35_0']
+         self.assertEqual([meta.dist() for meta in distributions], expected)
+         # Check that we didn't change the index.
+-        self.assertEqual(index, {}) 
++        self.assertEqual(index, {})
+ 
+ 
+ if __name__ == '__main__':
+diff --git a/conda_build_all/tests/unit/dummy_index.py b/conda_build_all/tests/unit/dummy_index.py
+index 48ef561..2b1ae86 100644
+--- a/conda_build_all/tests/unit/dummy_index.py
++++ b/conda_build_all/tests/unit/dummy_index.py
+@@ -4,6 +4,7 @@ import os
+ from conda_build.index import write_repodata
+ try:
+     import conda_build.api
++    from conda_build.utils import get_lock
+     extra_config = False
+ except ImportError:
+     import conda_build
+@@ -70,7 +71,8 @@ class DummyIndex(dict):
+         if not os.path.exists(channel_subdir):
+             os.mkdir(channel_subdir)
+         if hasattr(conda_build, 'api'):
+-            write_repodata({'packages': self, 'info': {}}, channel_subdir, conda_build.api.Config())
++            lock = get_lock(channel_subdir)
++            write_repodata({'packages': self, 'info': {}}, channel_subdir, lock, config=conda_build.api.Config())
+         else:
+             write_repodata({'packages': self, 'info': {}}, channel_subdir)
+ 

--- a/recipes/conda-build-all/gitpython/meta.yaml
+++ b/recipes/conda-build-all/gitpython/meta.yaml
@@ -1,0 +1,43 @@
+{% set version="2.0.8" %}
+
+package:
+  name: gitpython
+  version: {{ version }}
+
+source:
+  fn: GitPython-{{ version }}.tar.gz
+  url: https://github.com/gitpython-developers/GitPython/archive/{{ version }}.tar.gz
+  sha256: adbc08a2244f5f00cd8d0dc7a115b55f269ca1677799393a86d499b6a4dd513e
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - gitdb >=0.6.4
+
+test:
+  imports:
+    - git
+    - git.index
+    - git.objects
+    - git.objects.submodule
+    - git.refs
+    - git.repo
+
+about:
+  home: https://github.com/gitpython-developers/GitPython
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Python Git Library'
+  doc_url:  http://gitpython.readthedocs.org
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/conda-build-all/meta.yaml
+++ b/recipes/conda-build-all/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "1.0.1" %}
+
+package:
+  name: conda-build-all
+  version: {{ version }}
+
+source:
+    fn: conda-build-all_v{{ version }}.tar.gz
+    url: https://github.com/SciTools/conda-build-all/archive/v{{version}}.tar.gz
+    sha256: 1e34102f9055ce99500ce8ec87933d46a482cd20b865a180f2b064b4baf345f0
+    patches:
+    - conda_build2.patch
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  entry_points:
+    - conda-build-all = conda_build_all.cli:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - gitpython
+    - conda >4
+    - conda-build >=1.21.7
+    - anaconda-client
+    - mock
+
+test:
+  imports:
+    - conda_build_all
+  commands:
+    - conda build-all --version
+
+about:
+  license: BSD 3-clause
+  home: https://github.com/scitools/conda-build-all
+  summary: 'conda build-all is a conda subcommand which allows multiple distributions to be built (and uploaded) in a single command.'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/gitdb/meta.yaml
+++ b/recipes/gitdb/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "0.6.4"%}
+
+package:
+  name: gitdb
+  version: {{ version }}
+
+source:
+  fn: gitdb-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/g/gitdb/gitdb-{{ version }}.tar.gz
+  sha256: a3ebbc27be035a2e874ed904df516e35f4a29a778a764385de09de9e0f139658
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+    - smmap >=0.8.3
+
+test:
+  imports:
+    - gitdb
+    - gitdb.db
+
+about:
+  home: https://github.com/gitpython-developers/gitdb
+  license: BSD 3-Clause
+  summary: 'Git Object Database'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/smmap/meta.yaml
+++ b/recipes/smmap/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "0.9.0" %}
+
+package:
+  name: smmap
+  version: {{ version }}
+
+source:
+  fn: smmap-{{ version }}.tar.gz
+  url: https://github.com/gitpython-developers/smmap/archive/v{{ version }}.tar.gz
+  sha256: 2b0051557554241fc4ef8b127a6cc21b28f379663db37f1de1abb7c6efcaa498
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - smmap
+    - smmap.test
+
+about:
+  home: https://github.com/gitpython-developers/smmap
+  license: BSD 3-Clause
+  summary: 'A pure git implementation of a sliding window memory map manager.'
+
+extra:
+  recipe-maintainers:
+    - pelson
+    - ocefpaf


### PR DESCRIPTION
Once https://github.com/SciTools/conda-build-all/pull/71 is merged we can remove this.