### PR TITLE
New integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: generic
 
-os: osx
+os:
+  - osx
+  - linux
 
 sudo: false
 
@@ -9,7 +11,9 @@ env:
     secure: "ZnEdu0lLBRXVLnqSU9duTu+IjSnPs0YOkfvcyspbpI8OewCx+g5DiWRCjcU9GOGscoYoMdTUOwh/E6CloEhAlxaOxtAK4yKFhewu2bUwnZTWwoL+AL9pJZ9z1jUHAU5asAcganYP691g0YO/O9y7h2OedGrmAjDSigdAHE/FtgBuXANfJAIN78cP899XwYQyWYZmeLNtWTKD2kpKv1Z6Y5ivp7cmjn19wwLJekShNMEe2CiTY44rkwwHXNPuoKELQZEE+8TJdFbLm7rh5weucOqtvWuXr0BFS9Kbw/SLKZUWfnrZ9GttNRE7Gi+R/NhXWRIZw4rSkl0njw4jFu/tmojHDAq874hEWqLIjrdrWAqs9ee3JmfcyQQzWPiGIlshiilPC/nyV7Oo45RlPZiceMac5u05kjA1WLGzXnHHdQmfZ8/M7szGLN+jmFE0vYajM9mYihKWhQpIkPVVIEe2k6eRt06zoBqAP4yP/9SIOgW4ik+gwnCWflNEA2vGZV2+s+5KQ7Q8FB+9XjghUY8LooUNGkzasy7vjizaOIt4c2fC3cYQB2Lxhf0L6ulhB7v/u4SSi55bjGm3vI/SNA0pbXVFVaclsaBuTV4dLItRpjyy0quNPdji2oQEBKW58R9rB8Kv7YcHyv2ozty40p5nMutoWWQ3wy2BgsYkxWVcaY4="
 
 before_install:
-  - brew remove --ignore-dependencies --force $(brew list)
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+       brew remove --ignore-dependencies --force $(brew list) ;
+    fi
 
 install:
   # Install miniconda.
@@ -30,10 +34,22 @@ install:
 
   - conda info
 
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+       conda env create --file environment.yml ;
+       source activate ODM2 ;
+    fi
+
 script:
   - if [[ "$BINSTAR_TOKEN" == "" ]]; then
       export UPLOAD="";
     else
       export UPLOAD="--upload-channels odm2";
     fi
-  - conda-build-all ./recipes $UPLOAD --inspect-channels odm2 --matrix-conditions "numpy >=1.11" "python >=2.7,<3|>=3.5,<=3.6"
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+       conda-build-all ./recipes $UPLOAD --inspect-channels odm2 --matrix-conditions "numpy >=1.11" "python >=2.7,<3|>=3.5,<=3.6" ;
+    fi
+
+  # Packages integration tests via user notebooks.
+  - if [[ "$TEST_TARGET" == "linux" ]]; then
+      cd tests && python test_notebooks.py ;
+    fi

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,47 @@
+"""
+Notebooks tests
+----------------
+
+Execute all notebooks.
+
+"""
+
+from nbconvert.preprocessors import ExecutePreprocessor
+from nbconvert.exporters import Exporter, HTMLExporter
+
+
+def notebook_tester(fname):
+    raw_nb = Exporter().from_filename(fname)
+    raw_nb[0].metadata.setdefault('kernelspec', {})['name'] = 'python'
+    preproc = ExecutePreprocessor(timeout=-1)
+    try:
+        exec_nb = preproc.preprocess(*raw_nb)
+    except Exception as e:
+        return '[Failed]\n{}'.format(e)
+
+    out_nb = HTMLExporter().from_notebook_node(*exec_nb)
+    fout = fname.replace('.ipynb', '.html')
+    with open(fout, 'w') as f:
+        f.write(out_nb[0])
+    return '[Passed]'
+
+
+if __name__ == '__main__':
+    import os
+    import sys
+    import glob
+
+    rootpath = os.path.join(os.path.abspath(os.path.pardir), 'notebooks')
+    nblist = glob.glob(os.path.join(rootpath, '*.ipynb'))
+
+    fail = False
+    for ipynb in sorted(nblist):
+        print('[Running notebook]: {}'.format(ipynb))
+        ret = notebook_tester(ipynb)
+        if 'Failed' in ret:
+            fail = True
+        print('{}\n'.format(ret))
+    if fail:
+        sys.exit(1)
+    else:
+        sys.exit(0)


### PR DESCRIPTION
Without binder to run the notebooks that perform the integration tests we need a new `Linux` instance to run them.

In this PR:

- added another Travis-CI test for `Linux`;
- installs the `ODM2` environment;
- run the notebook and check for errors.

Caveat: because this runs concurrently with the builds we are always testing what is already in the channel and not what is being build at the moment!

To do: publish the resulting notebook HTML so we can inspect the errors.