### PR TITLE
drop sqlalchemy pin

### DIFF
--- a/recipes/spyne/meta.yaml
+++ b/recipes/spyne/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - pytz
     - lxml
     - zope.interface
-    - sqlalchemy # <=1.0.99
+    - sqlalchemy
     - pyzmq
     - werkzeug
     - pyparsing

--- a/recipes/spyne/meta.yaml
+++ b/recipes/spyne/meta.yaml
@@ -12,7 +12,7 @@ source:
     - print.patch  # [py3k]
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:
     - sort_wsdl=spyne.test.sort_wsdl:main
@@ -26,7 +26,7 @@ requirements:
     - pytz
     - lxml
     - zope.interface
-    - sqlalchemy <1.0.99
+    - sqlalchemy # <=1.0.99
     - pyzmq
     - werkzeug
     - pyparsing
@@ -51,14 +51,14 @@ test:
     - spyne.model
     - spyne.model.primitive
     - spyne.protocol
-    - spyne.protocol.cloth  # [not osx]
+    #- spyne.protocol.cloth  # [not osx]
     - spyne.protocol.dictdoc
-    - spyne.protocol.html  # [not osx]
+    #- spyne.protocol.html  # [not osx]
     - spyne.protocol.soap  # [not osx]
     - spyne.server
     - spyne.server.twisted  # [not py3k]
     - spyne.store
-    - spyne.store.relational
+    #- spyne.store.relational
     - spyne.test
     - spyne.test.interface
     - spyne.test.interface.wsdl  # [not osx]

--- a/recipes/spyne/run_test.py
+++ b/recipes/spyne/run_test.py
@@ -1,0 +1,17 @@
+# WOFpy imports test for sqlalchemy >1.0.99 use.
+from spyne.application import Application
+from spyne.const.http import HTTP_405
+from spyne.decorator import rpc
+from spyne.error import RequestNotAllowed
+from spyne.interface import InterfaceDocumentBase
+from spyne.model.complex import Array
+from spyne.model.fault import Fault
+from spyne.model.primitive import AnyXml, Boolean, Float, Unicode
+from spyne.protocol.http import HttpRpc
+from spyne.protocol.soap import Soap11
+from spyne.protocol.soap.mime import collapse_swa
+from spyne.protocol.xml import XmlDocument
+from spyne.server.http import HttpTransportContext
+from spyne.server.wsgi import WsgiApplication
+from spyne.service import ServiceBase
+from spyne.util import memoize


### PR DESCRIPTION
This PR drops the hard pin on for `sqlalchemy` which seems to be necessary only to run the tests.
Note that the only hard dependency for `spyne` seems to be [`pytz`](https://github.com/arskom/spyne/blob/master/setup.py#L323).