### PR TITLE
Updates wheels noarch

### DIFF
--- a/recipes/branca/meta.yaml
+++ b/recipes/branca/meta.yaml
@@ -5,18 +5,19 @@ package:
   version: {{ version }}
 
 source:
-  fn: branca-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/b/branca/branca-{{ version }}.tar.gz
   sha256: 327b0bae73a519f25dc2f320d8d9f1885aad2e8e5105add1496269d5391b8ea4
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 1
+  skip: True  # [win or osx]
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - jinja2

--- a/recipes/folium/meta.yaml
+++ b/recipes/folium/meta.yaml
@@ -1,22 +1,23 @@
-{% set version = "0.3.0" %}
+{% set version = "0.5.0" %}
 
 package:
   name: folium
   version: {{ version }}
 
 source:
-  fn: folium-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/f/folium/folium-{{ version }}.tar.gz
-  sha256: 7729ddd6766b9c5dab17b3709e2387935fd5c655872f1cbab7b7036474415217
+  sha256: 748944521146d85c6cd6230acf234e885864cd0f42fea3758d655488517e5e6e
 
 build:
-  number: 1
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 0
+  skip: True  # [win or osx]
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - branca

--- a/recipes/folium/meta.yaml
+++ b/recipes/folium/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - jinja2
     - numpy
     - pandas
+    - requests
 
 test:
   imports:

--- a/recipes/geoalchemy-odm2/meta.yaml
+++ b/recipes/geoalchemy-odm2/meta.yaml
@@ -5,19 +5,19 @@ package:
   version: {{ version }}
 
 source:
-  fn: geoalchemy-odm2-{{ version }}.tar.gz
   url: https://github.com/ODM2/geoalchemy/archive/v{{ version }}.tar.gz
   sha256: fbbfb448f601037c9bc15c5314047cd049a1c2dd5659d6078c6ef3ba1cc8508e
 
 build:
-  number: 0
-  preserve_egg_dir: True
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 1
+  skip: True  # [win or osx]
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
     - sqlalchemy >=0.6.1
     - six
   run:

--- a/recipes/gitdb/meta.yaml
+++ b/recipes/gitdb/meta.yaml
@@ -11,7 +11,6 @@ source:
 build:
   number: 1
   skip: True  # [win or osx]
-  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipes/gitdb/meta.yaml
+++ b/recipes/gitdb/meta.yaml
@@ -5,17 +5,19 @@ package:
   version: {{ version }}
 
 source:
-  fn: gitdb-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/g/gitdb/gitdb-{{ version }}.tar.gz
   sha256: a3ebbc27be035a2e874ed904df516e35f4a29a778a764385de09de9e0f139658
 
 build:
-  number: 0
-  script: python setup.py install
+  number: 1
+  skip: True  # [win or osx]
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
+    - pip
   run:
     - python
     - smmap >=0.8.3

--- a/recipes/gitpython/meta.yaml
+++ b/recipes/gitpython/meta.yaml
@@ -1,22 +1,23 @@
-{% set version="2.1.3" %}
+{% set version="2.1.8" %}
 
 package:
   name: gitpython
   version: {{ version }}
 
 source:
-  fn: GitPython-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/G/GitPython/GitPython-{{ version }}.tar.gz
-  sha256: 3826185b11e1fc372e7d31251e9b65e11ccb7c27f82c771d619048bdb5b66c81
+  sha256: ad61bc25deadb535b047684d06f3654c001d9415e1971e51c9c20f5b510076e9
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: True  # [win or osx]
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - gitdb >=0.6.4

--- a/recipes/msinttypes/meta.yaml
+++ b/recipes/msinttypes/meta.yaml
@@ -5,7 +5,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: msinttypes-{{ version }}.zip
   url: https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/msinttypes/msinttypes-{{ version }}.zip
   sha256: 6e66d88de18aac0775890e94aa621853aa1d572136e3783ce130510d8fb6a55d
 

--- a/recipes/odm2api/meta.yaml
+++ b/recipes/odm2api/meta.yaml
@@ -9,14 +9,14 @@ source:
   sha256: d6f86c608ed6ab5809411e159ddfd512c9ed9d9e224cedd297cb56a6031407ff
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py3k]
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - pyodbc

--- a/recipes/psycopg2/bld.bat
+++ b/recipes/psycopg2/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1

--- a/recipes/psycopg2/build.sh
+++ b/recipes/psycopg2/build.sh
@@ -2,7 +2,7 @@
 
 export LDFLAGS="${LDFLAGS} -L$PREFIX/lib -lssl"
 
-$PYTHON setup.py install
+$PYTHON -m pip install --no-deps --ignore-installed .
 
 if [[ `uname` == 'Darwin' ]]; then
      PG_LIB=$(pg_config --libdir)

--- a/recipes/psycopg2/have_openssl.patch
+++ b/recipes/psycopg2/have_openssl.patch
@@ -1,13 +1,13 @@
-diff --git setup.cfg setup.cfg
-index 7318323..dccb173 100644
---- setup.cfg
-+++ setup.cfg
-@@ -1,7 +1,7 @@
- [build_ext]
- define = 
+diff --git a/setup.cfg b/setup.cfg
+index 6d1c282..f3e2889 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -3,7 +3,7 @@ define =
+ pg_config = 
  use_pydatetime = 1
+ mx_include_dir = 
 -have_ssl = 0
 +have_ssl = 1
+ static_libpq = 0
+ libraries = 
  
- [egg_info]
- tag_build = 

--- a/recipes/psycopg2/meta.yaml
+++ b/recipes/psycopg2/meta.yaml
@@ -1,29 +1,30 @@
-{% set version = "2.6.2" %}
+{% set version = "2.7.3.2" %}
 
 package:
   name: psycopg2
   version: {{ version }}
 
 source:
-  fn: psycopg2-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/p/psycopg2/psycopg2-{{ version }}.tar.gz
-  sha256: 70490e12ed9c5c818ecd85d185d363335cc8a8cbf7212e3c185431c79ff8c05c
+  sha256: 5c3213be557d0468f9df8fe2487eaf2990d9799202c5ff5cb8d394d09fad9b2a
   patches:
     - have_openssl.patch
 
 build:
-  number: 2
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .  # [win]
 
 requirements:
   build:
+    - python
+    - pip
     - openssl 1.0.*
     - postgresql
-    - python
   run:
+    - python
     # libpq is a repackaging of only the library to connect to postgres
     - libpq
     - openssl 1.0.*
-    - python
 
 test:
   imports:

--- a/recipes/python-dateutil/meta.yaml
+++ b/recipes/python-dateutil/meta.yaml
@@ -5,18 +5,19 @@ package:
   version: {{ version }}
 
 source:
-  fn: python-dateutil-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/p/python-dateutil/python-dateutil-{{ version }}.tar.gz
   sha256: 62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
+  skip: True  # [win or osx]
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - six

--- a/recipes/shapely/meta.yaml
+++ b/recipes/shapely/meta.yaml
@@ -5,7 +5,6 @@ package:
   version: {{ version }}
 
 source:
-  fn: Shapely-{{ version }}.tar.gz
   url: https://github.com/Toblerity/Shapely/archive/{{ version }}.tar.gz
   sha256: 85dd42a3e229f434642ad39744ebc82cd352931c6686d858bd9607649b5a4d8a
   patches:

--- a/recipes/smmap/meta.yaml
+++ b/recipes/smmap/meta.yaml
@@ -5,18 +5,19 @@ package:
   version: {{ version }}
 
 source:
-  fn: smmap-{{ version }}.tar.gz
   url: https://github.com/gitpython-developers/smmap/archive/v{{ version }}.tar.gz
   sha256: 2b0051557554241fc4ef8b127a6cc21b28f379663db37f1de1abb7c6efcaa498
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
+  skip: True  # [win or osx]
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
 

--- a/recipes/spyne/meta.yaml
+++ b/recipes/spyne/meta.yaml
@@ -5,15 +5,14 @@ package:
   version: {{ version }}
 
 source:
-  fn: spyne-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/s/spyne/spyne-{{ version }}.tar.gz
   sha256: d37dfba126a6ce4e201ad63e31beb0a0e158b4580b1aa753c12310134a4cf0ae
   patches:
-    - print.patch  # [py3k]
+    - print.patch
 
 build:
-  number: 1
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 2
+  script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - sort_wsdl=spyne.test.sort_wsdl:main
 

--- a/recipes/sqlalchemy/meta.yaml
+++ b/recipes/sqlalchemy/meta.yaml
@@ -1,17 +1,16 @@
-{% set version = "1.1.7" %}
+{% set version = "1.2.1" %}
 
 package:
   name: sqlalchemy
   version: {{ version }}
 
 source:
-  fn: SQLAlchemy-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/S/SQLAlchemy/SQLAlchemy-{{ version }}.tar.gz
-  sha256: 9308b2886285dec57aa9e569a0519220e83515e15c6e3eda803c07deb7c1cbad
+  sha256: 9ede7070d6fd18f28058be88296ed67893e2637465516d6a596cd9afea97b154
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
@@ -21,8 +20,6 @@ requirements:
     - python
 
 test:
-  requires:
-    - mock  # [py27]
   imports:
     - sqlalchemy
     - sqlalchemy.connectors

--- a/recipes/sqlalchemy/meta.yaml
+++ b/recipes/sqlalchemy/meta.yaml
@@ -38,8 +38,6 @@ test:
     - sqlalchemy.ext.declarative
     - sqlalchemy.orm
     - sqlalchemy.sql
-    - sqlalchemy.testing
-    - sqlalchemy.testing.plugin
     - sqlalchemy.util
 
 about:

--- a/recipes/suds-jurko/meta.yaml
+++ b/recipes/suds-jurko/meta.yaml
@@ -5,18 +5,19 @@ package:
   version: {{ version }}
 
 source:
-  fn: suds-jurko-{{ version }}.tar.bz2
   url: https://pypi.io/packages/source/s/suds-jurko/suds-jurko-{{ version }}.tar.bz2
   sha256: 29edb72fd21e3044093d86f33c66cf847c5aaab26d64cb90e69e528ef014e57f
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 1
+  skip: True  # [win or osx]
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
 

--- a/recipes/suds-jurko/meta.yaml
+++ b/recipes/suds-jurko/meta.yaml
@@ -10,8 +10,6 @@ source:
 
 build:
   number: 1
-  skip: True  # [win or osx]
-  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipes/uwsgi/build.sh
+++ b/recipes/uwsgi/build.sh
@@ -2,4 +2,4 @@ export UWSGI_PROFILE="$RECIPE_DIR/uwsgi_config.ini"
 export UWSGI_INCLUDES="$PREFIX/include,$PREFIX/include/openssl"
 export LDFLAGS="-L$PREFIX/lib $LDFLAGS"
 
-$PYTHON setup.py install --single-version-externally-managed --record record.txt
+$PYTHON -m pip install --no-deps --ignore-installed .

--- a/recipes/uwsgi/meta.yaml
+++ b/recipes/uwsgi/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 572ef9696b97595b4f44f6198fe8c06e6f4e6351d930d22e5330b071391272ff
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 

--- a/recipes/uwsgi/meta.yaml
+++ b/recipes/uwsgi/meta.yaml
@@ -5,30 +5,30 @@ package:
   version: {{ version }}
 
 source:
-  fn: uwsgi-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/u/uWSGI/uwsgi-{{ version }}.tar.gz
   sha256: 572ef9696b97595b4f44f6198fe8c06e6f4e6351d930d22e5330b071391272ff
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 
 requirements:
   build:
     - python
-    - libxml2  # [not win]
+    - pip
+    - libxml2
     - openssl 1.0.*
     - pcre
     - yaml
-    - zlib 1.2*
+    - zlib 1.2.11
   run:
     - python
-    - libxml2  # [not win]
+    - libxml2
     - openssl 1.0.*
     - pcre
     - yaml
-    - zlib 1.2*
+    - zlib 1.2.11
 
 test:
   source_files:

--- a/recipes/valideer/meta.yaml
+++ b/recipes/valideer/meta.yaml
@@ -5,18 +5,19 @@ package:
   version: {{ version }}
 
 source:
-  fn: valideer-{{ version }}.tar.gz
   url: https://github.com/podio/valideer/archive/{{ version }}.tar.gz
   sha256: be554a6f93eab049dd419a181c409a2e6421696263c7eb472cbdfaa46df9d1b1
 
 build:
-  number: 1
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 2
+  skip: True  # [win or osx]
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - decorator

--- a/recipes/wofpy/meta.yaml
+++ b/recipes/wofpy/meta.yaml
@@ -11,14 +11,14 @@ source:
 build:
   number: 0
   skip: True  # [py3k]
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - wofpy_config = wof.wofpy_config:main
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - configparser  # [py2k]

--- a/recipes/yodatools/meta.yaml
+++ b/recipes/yodatools/meta.yaml
@@ -9,16 +9,16 @@ source:
   sha256: 8b370029b945da34d093865f221ac734570f97906f598cbd21ff1ef1e94919f9
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py3k]
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python -m pip install --no-deps --ignore-installed .
   entry_points:
     - yodatools = yodatools.dataloader.controller.Main:main
 
 requirements:
   build:
     - python
-    - setuptools
+    - pip
   run:
     - python
     - numpy


### PR DESCRIPTION
In this PR:

- build wheels instead of eggs
- update many recipes
- use `noarch` as much as possible

this should help us to move to newer build tools.